### PR TITLE
Replaced "proxing"

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -1163,7 +1163,7 @@ care of ordering of the underlying asynchronous operations yourself.
 Meta-Programming
 ================
 
-Proxing
+Proxies
 -------
 
 Hooking into runtime-level object meta-operations.


### PR DESCRIPTION
"Proxing" isn't an English word. "Proxying" is, but I chose "Proxies" because in the spec, "Proxy" is more noun than verb.
